### PR TITLE
Add Chain Reaction game with minimax AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# py
-none
+# Chain Reaction Game with Minimax AI
+
+This repository contains a simple implementation of the Chain Reaction board game.
+It includes:
+
+- `board.py` – game logic and board representation.
+- `heuristics.py` – a set of evaluation heuristics for the AI.
+- `ai.py` – minimax search with alpha–beta pruning.
+- `human_vs_ai.py` – text UI using the file protocol described in the assignment.
+- `ai_vs_ai.py` – run matches between two AI agents.
+
+## Running
+
+To play against the AI using the file protocol:
+
+```bash
+python3 human_vs_ai.py
+```
+
+This will create a `gamestate.txt` file. Edit the file after each AI move to
+enter your move, then save it and the AI will respond.
+
+For quick AI vs AI matches:
+
+```bash
+python3 ai_vs_ai.py
+```

--- a/ai.py
+++ b/ai.py
@@ -1,0 +1,42 @@
+"""Minimax AI with alpha-beta pruning for Chain Reaction."""
+from typing import Tuple, Optional
+from board import Board
+from heuristics import HEURISTICS
+
+
+def minimax(board: Board, depth: int, alpha: float, beta: float, maximizing: bool, color: str, heuristic_name: str) -> Tuple[int, Optional[Tuple[int,int]]]:
+    opp = 'B' if color == 'R' else 'R'
+    if depth == 0 or board.is_terminal():
+        value = HEURISTICS[heuristic_name](board, color)
+        return value, None
+    if maximizing:
+        max_val = float('-inf')
+        best_move = None
+        for move in board.legal_moves(color):
+            new_board = board.clone()
+            new_board.apply_move(color, *move)
+            val, _ = minimax(new_board, depth-1, alpha, beta, False, color, heuristic_name)
+            if val > max_val:
+                max_val = val
+                best_move = move
+            alpha = max(alpha, val)
+            if beta <= alpha:
+                break
+        return max_val, best_move
+    else:
+        min_val = float('inf')
+        for move in board.legal_moves(opp):
+            new_board = board.clone()
+            new_board.apply_move(opp, *move)
+            val, _ = minimax(new_board, depth-1, alpha, beta, True, color, heuristic_name)
+            if val < min_val:
+                min_val = val
+            beta = min(beta, val)
+            if beta <= alpha:
+                break
+        return min_val, None
+
+
+def best_move(board: Board, color: str, depth: int = 3, heuristic: str = 'weighted') -> Tuple[int,int]:
+    _, move = minimax(board, depth, float('-inf'), float('inf'), True, color, heuristic)
+    return move

--- a/ai_vs_ai.py
+++ b/ai_vs_ai.py
@@ -1,0 +1,26 @@
+"""Run AI vs AI matches for experimentation."""
+from board import Board
+from ai import best_move
+
+
+def play_game(depth_a=2, depth_b=2, heuristic_a='weighted', heuristic_b='weighted'):
+    board = Board()
+    current = 'R'
+    while not board.is_terminal():
+        if current == 'R':
+            move = best_move(board, 'R', depth=depth_a, heuristic=heuristic_a)
+            if move is None:
+                break
+            board.apply_move('R', *move)
+            current = 'B'
+        else:
+            move = best_move(board, 'B', depth=depth_b, heuristic=heuristic_b)
+            if move is None:
+                break
+            board.apply_move('B', *move)
+            current = 'R'
+    return board.winner()
+
+if __name__ == '__main__':
+    winner = play_game()
+    print('Winner:', winner)

--- a/board.py
+++ b/board.py
@@ -1,0 +1,140 @@
+# Board representation and game logic for Chain Reaction
+# Each cell may contain a stack of orbs belonging to Red (R) or Blue (B)
+# When the stack reaches the cell's critical mass, it explodes to neighbors
+from copy import deepcopy
+
+class Cell:
+    def __init__(self, count=0, color=None):
+        self.count = count
+        self.color = color  # 'R' or 'B' or None
+
+    def is_empty(self):
+        return self.count == 0
+
+class Board:
+    def __init__(self, rows=9, cols=6):
+        self.rows = rows
+        self.cols = cols
+        self.grid = [[Cell() for _ in range(cols)] for _ in range(rows)]
+
+    def clone(self):
+        return deepcopy(self)
+
+    def critical_mass(self, r, c):
+        # Number of orthogonal neighbors
+        neighbors = 4
+        if r == 0 or r == self.rows - 1:
+            neighbors -= 1
+        if c == 0 or c == self.cols - 1:
+            neighbors -= 1
+        return neighbors
+
+    def in_bounds(self, r, c):
+        return 0 <= r < self.rows and 0 <= c < self.cols
+
+    def get(self, r, c):
+        return self.grid[r][c]
+
+    def set(self, r, c, cell):
+        self.grid[r][c] = cell
+
+    def legal_moves(self, color):
+        moves = []
+        for r in range(self.rows):
+            for c in range(self.cols):
+                cell = self.grid[r][c]
+                if cell.is_empty() or cell.color == color:
+                    moves.append((r, c))
+        return moves
+
+    def apply_move(self, color, r, c):
+        # Add orb and resolve chain reactions
+        target = self.grid[r][c]
+        if target.is_empty():
+            target.color = color
+        target.count += 1
+        self._resolve_explosions([(r, c)])
+
+    def _resolve_explosions(self, queue):
+        while queue:
+            r, c = queue.pop(0)
+            cell = self.grid[r][c]
+            if cell.count >= self.critical_mass(r, c):
+                # explosion
+                color = cell.color
+                cell.count -= self.critical_mass(r, c)
+                if cell.count == 0:
+                    cell.color = None
+                for dr, dc in ((1,0),(-1,0),(0,1),(0,-1)):
+                    nr, nc = r+dr, c+dc
+                    if self.in_bounds(nr, nc):
+                        neighbor = self.grid[nr][nc]
+                        if neighbor.is_empty():
+                            neighbor.color = color
+                        else:
+                            neighbor.color = color
+                        neighbor.count += 1
+                        if neighbor.count >= self.critical_mass(nr, nc):
+                            queue.append((nr, nc))
+
+    def count_orbs(self, color):
+        total = 0
+        for r in range(self.rows):
+            for c in range(self.cols):
+                cell = self.grid[r][c]
+                if cell.color == color:
+                    total += cell.count
+        return total
+
+    def is_terminal(self):
+        red = self.count_orbs('R')
+        blue = self.count_orbs('B')
+        if red == 0 and blue == 0:
+            return False  # empty board at start
+        return red == 0 or blue == 0
+
+    def winner(self):
+        red = self.count_orbs('R')
+        blue = self.count_orbs('B')
+        if red == 0 and blue == 0:
+            return None
+        if red == 0:
+            return 'B'
+        if blue == 0:
+            return 'R'
+        return None
+
+    @classmethod
+    def from_lines(cls, lines):
+        rows = len(lines)
+        cols = len(lines[0].split())
+        board = cls(rows, cols)
+        for r, line in enumerate(lines):
+            parts = line.strip().split()
+            for c, token in enumerate(parts):
+                if token == '0':
+                    continue
+                count = int(token[:-1])
+                color = token[-1]
+                board.grid[r][c].count = count
+                board.grid[r][c].color = color
+        return board
+
+    def to_lines(self):
+        lines = []
+        for r in range(self.rows):
+            row = []
+            for c in range(self.cols):
+                cell = self.grid[r][c]
+                if cell.is_empty():
+                    row.append('0')
+                else:
+                    row.append(f"{cell.count}{cell.color}")
+            lines.append(' '.join(row))
+        return lines
+
+    def display(self):
+        for line in self.to_lines():
+            print(line)
+
+

--- a/heuristics.py
+++ b/heuristics.py
@@ -1,0 +1,54 @@
+"""Heuristic evaluation functions for Chain Reaction."""
+from board import Board
+
+
+def orb_difference(board: Board, color: str) -> int:
+    """Difference in total orb count."""
+    opp = 'B' if color == 'R' else 'R'
+    return board.count_orbs(color) - board.count_orbs(opp)
+
+
+def mobility(board: Board, color: str) -> int:
+    """Number of legal moves available."""
+    return len(board.legal_moves(color))
+
+
+def corner_control(board: Board, color: str) -> int:
+    """Control of corner cells gives bonus."""
+    corners = [(0,0), (0, board.cols-1), (board.rows-1,0), (board.rows-1, board.cols-1)]
+    score = 0
+    for r, c in corners:
+        cell = board.get(r, c)
+        if cell.color == color:
+            score += 3
+    return score
+
+
+def critical_mass_distance(board: Board, color: str) -> int:
+    """Preference for cells close to exploding."""
+    total = 0
+    for r in range(board.rows):
+        for c in range(board.cols):
+            cell = board.get(r, c)
+            if cell.color == color:
+                needed = board.critical_mass(r, c) - cell.count
+                total -= needed  # fewer needed is better
+    return total
+
+
+def weighted_heuristic(board: Board, color: str) -> int:
+    """Combine several heuristics."""
+    return (
+        3 * orb_difference(board, color)
+        + mobility(board, color)
+        + corner_control(board, color)
+        + critical_mass_distance(board, color)
+    )
+
+HEURISTICS = {
+    'orb_diff': orb_difference,
+    'mobility': mobility,
+    'corner': corner_control,
+    'critical': critical_mass_distance,
+    'weighted': weighted_heuristic,
+}

--- a/human_vs_ai.py
+++ b/human_vs_ai.py
@@ -1,0 +1,55 @@
+"""Simple command-line UI for Chain Reaction using file protocol."""
+import os
+import time
+from board import Board
+from ai import best_move
+
+STATE_FILE = 'gamestate.txt'
+
+
+def write_state(header: str, board: Board):
+    lines = [header]
+    lines += board.to_lines()
+    with open(STATE_FILE, 'w') as f:
+        f.write('\n'.join(lines))
+
+
+def read_state() -> (str, Board):
+    with open(STATE_FILE, 'r') as f:
+        lines = [line.strip() for line in f.readlines() if line.strip()]
+    header = lines[0]
+    board = Board.from_lines(lines[1:])
+    return header, board
+
+
+def wait_for_human_move(board: Board, color: str):
+    while True:
+        header, board_state = read_state()
+        if header.startswith('Human Move'):
+            return board_state
+        time.sleep(0.5)
+
+
+def main():
+    board = Board()
+    current = 'R'  # human is Red
+    write_state('Human Move:', board)
+    while not board.is_terminal():
+        header, board = read_state()
+        if header.startswith('Human Move'):
+            # AI turn
+            move = best_move(board, 'B', depth=2)
+            if move is None:
+                print('AI resigns')
+                return
+            board.apply_move('B', *move)
+            write_state('AI Move:', board)
+            board.display()
+        else:
+            # wait for human to update the file
+            board = wait_for_human_move(board, 'R')
+    winner = board.winner()
+    print('Winner:', winner)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement board and chain reaction rules
- add multiple heuristics for evaluating boards
- implement minimax search with alpha-beta pruning
- provide text-based UI using the given file protocol
- include script for AI vs AI experiments

## Testing
- `python3 -m py_compile board.py ai.py heuristics.py human_vs_ai.py ai_vs_ai.py`
- `python3 ai_vs_ai.py`

------
https://chatgpt.com/codex/tasks/task_e_684eb76a4cec83278db189d9e60f7d04