### PR TITLE
Fix explosion cleanup

### DIFF
--- a/Try_1_o_four_mini_high/engine.py
+++ b/Try_1_o_four_mini_high/engine.py
@@ -32,21 +32,21 @@ def write_state(header, board, path='gamestate.txt'):
 
 
 def explode(board):
-    changed=True
+    changed = True
     while changed:
-        changed=False
+        changed = False
         for r in range(BOARD_ROWS):
             for c in range(BOARD_COLS):
-                cnt,col=board[r][c]
-                if cnt>=CRIT_MASS[(r,c)]:
-                    changed=True
-                    board[r][c]=(cnt-CRIT_MASS[(r,c)],col)
-                    for dr,dc in [(1,0),(-1,0),(0,1),(0,-1)]:
-                        nr, nc = r+dr, c+dc
-                        if 0<=nr<BOARD_ROWS and 0<=nc<BOARD_COLS:
-                            ncnt,ncol=board[nr][nc]
-                            board[nr][nc]=(ncnt+1, col)
-        # conversion happens naturally by writing col
+                cnt, col = board[r][c]
+                if cnt >= CRIT_MASS[(r, c)] and col is not None:
+                    changed = True
+                    new_cnt = cnt - CRIT_MASS[(r, c)]
+                    board[r][c] = (new_cnt, col if new_cnt > 0 else None)
+                    for dr, dc in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+                        nr, nc = r + dr, c + dc
+                        if 0 <= nr < BOARD_ROWS and 0 <= nc < BOARD_COLS:
+                            ncnt, _ = board[nr][nc]
+                            board[nr][nc] = (ncnt + 1, col)
     return board
 
 


### PR DESCRIPTION
## Summary
- fix `explode` so cells clear color when orbs drop to zero

## Testing
- `python3 -m py_compile Try_1_o_four_mini_high/engine.py`
- `node -e "require('./Try_1_o_four_mini_high/backend.js')"` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68502a8aced0832795c8f51ee62acf36